### PR TITLE
Motor Knockout

### DIFF
--- a/src/main/kotlin/frc/robot/Constants.kt
+++ b/src/main/kotlin/frc/robot/Constants.kt
@@ -19,5 +19,12 @@ class Constants {
   companion object {
     // Put Constants inside the companion object to make them globally accessible.
     // ex. val motorPort: Int = 0
+    val Drive_Kp: Double = 1.0;
+    val Drive_Ki: Double = 0.0;
+    val Drive_Kd: Double = 0.0;
+    val dpp: Double = 1.0;
+    val kToleranceRPS: Double = 1.0;
+    val kTargetRPS: Double = 2.0;
+    val Drive_KTolerance_Deg: Double = 2.0;
   }
 }

--- a/src/main/kotlin/frc/robot/Constants.kt
+++ b/src/main/kotlin/frc/robot/Constants.kt
@@ -28,5 +28,9 @@ class Constants {
 
     val TurnToAngleleranceDeg = 2.0
     val TurnToAngleRateToleranceDegPerS = 1.0
+
+    val subsysP = 0.03
+    val subsysI = 0.0
+    val subsysD = 0.0
   }
 }

--- a/src/main/kotlin/frc/robot/Constants.kt
+++ b/src/main/kotlin/frc/robot/Constants.kt
@@ -26,6 +26,12 @@ class Constants {
     val TurnToAngleI = 0.0
     val TurnToAngleD = 0.01
 
+    val TarSpeedP = 0.03
+    val TarSpeedI = 0.0
+    val TarSpeedD = 0.0
+    val TarSpeedleranceDeg = 2.0
+    val TarSpeedToleranceDegPerS = 1.0
+
     val TurnToAngleleranceDeg = 2.0
     val TurnToAngleRateToleranceDegPerS = 1.0
 

--- a/src/main/kotlin/frc/robot/Robot.kt
+++ b/src/main/kotlin/frc/robot/Robot.kt
@@ -21,7 +21,6 @@ class Robot : TimedRobot() {
   lateinit var m_autonomousCommand: Command
 
   lateinit var m_robotContainer: RobotContainer
-
   /**
    * This function is run when the robot is first started up and should be used for any
    * initialization code.

--- a/src/main/kotlin/frc/robot/RobotContainer.kt
+++ b/src/main/kotlin/frc/robot/RobotContainer.kt
@@ -21,7 +21,11 @@ import com.ctre.phoenix.motorcontrol.ControlMode
 import com.ctre.phoenix.motorcontrol.can.*
 import com.kauailabs.navx.frc.AHRS
 import edu.wpi.first.wpilibj2.command.button.JoystickButton
-
+import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard
+import edu.wpi.first.networktables.NetworkTableEntry
+import edu.wpi.first.networktables.EntryNotification
+import edu.wpi.first.networktables.EntryListenerFlags
+import edu.wpi.first.networktables.NetworkTableInstance
 /**
  * This class is where the bulk of the robot should be declared.  Since Command-based is a
  * "declarative" paradigm, very little robot logic should actually be handled in the {@link Robot}
@@ -54,6 +58,15 @@ class RobotContainer {
 
   val joystickDriveCommand = JoystickDrive(drivetrain, joystick0)
 
+  val main = Shuffleboard.getTab("Main") // TODO: Rename this sometime.
+  val knockout = Shuffleboard.getTab("Auto mode")
+  var speed = 0 // leo: for a worthless experiment :)
+
+  var knockFrontLeft: NetworkTableEntry = knockout.add("Knockout FrontLeft",false).withWidget("Toggle Button").getEntry()
+  var knockBackLeft: NetworkTableEntry = knockout.add("Knockout BackLeft",false).withWidget("Toggle Button").getEntry()
+  var knockFrontRight: NetworkTableEntry = knockout.add("Knockout FrontRight",false).withWidget("Toggle Button").getEntry()
+  var knockBackRight: NetworkTableEntry = knockout.add("Knockout BackRight",false).withWidget("Toggle Button").getEntry()
+
 
   /**
    * The container for the robot.  Contains subsystems, OI devices, and commands.
@@ -63,7 +76,10 @@ class RobotContainer {
     configureButtonBindings()
     configureDefaultCommands()
     m_autoCommandChooser.setDefaultOption("Default Auto", m_autoCommand)
-    SmartDashboard.putData("Auto mode", m_autoCommandChooser)
+    Shuffleboard.selectTab("Main")
+    main.add("Auto mode", m_autoCommandChooser)
+    
+    
   }
 
   /**
@@ -76,6 +92,37 @@ class RobotContainer {
     val alignButton = JoystickButton(joystick0, 3)
 
     alignButton.whenPressed(TurnToAngle(drivetrain, 90.0))
+    
+    // Knockout stuff
+    knockFrontLeft.addListener({event ->
+       if(knockFrontLeft.getBoolean(false)) {
+         motorFrontLeft.disable()
+       }
+       
+      }, EntryListenerFlags.kNew or EntryListenerFlags.kUpdate)
+    
+    knockFrontRight.addListener({event ->
+        if(knockFrontRight.getBoolean(false)){
+          motorFrontRight.disable()
+        }
+       }, EntryListenerFlags.kNew or EntryListenerFlags.kUpdate)
+    
+    knockBackLeft.addListener({event ->
+        if(knockBackLeft.getBoolean(false)){
+          motorBackLeft.disable()
+        }
+       }, EntryListenerFlags.kNew or EntryListenerFlags.kUpdate)
+    
+    knockBackRight.addListener({event ->
+        if(knockBackRight.getBoolean(false)){
+          motorBackRight.disable()
+        }
+       }, EntryListenerFlags.kNew or EntryListenerFlags.kUpdate)
+    //val shiftUpButton = JoystickButton(joystick0, 2)
+    //val shiftDownButton = JoystickButton(joystick0, 4)
+
+    //shiftUpButton.whenPressed(speed++10)
+    //shiftDownButton.whenPressed(speed--10)
   }
 
   /**

--- a/src/main/kotlin/frc/robot/commands/testPIDCommand.kt
+++ b/src/main/kotlin/frc/robot/commands/testPIDCommand.kt
@@ -14,12 +14,13 @@ import edu.wpi.first.wpilibj2.command.PIDCommand
 import edu.wpi.first.wpilibj.controller.PIDController
 import edu.wpi.first.wpilibj.drive.DifferentialDrive
 
-class testPIDCommand(val TargetAngle: Double, val drivetrain = DrivetrainSubsystem(DifferentialDrive)) : PIDCommand(
-    PIDController(Constants.Drive_Kp,Constants.Drive_Ki,Constants.Drive_Kd),
-    drivetrain::getHeading,
-    targetAngle,
-    output -> drivetrain.arcadeDrive(0,0),
-    drive)
+class testPIDCommand(val TargetAngle: Double, val drivetrain: DrivetrainSubsystem) : PIDCommand(
+    PIDController(Constants.TurnToAngleP,Constants.TurnToAngleI,Constants.TurnToAngleD),
+    drivetrain::getAngle,
+    TargetAngle,
+    {output:Double -> drivetrain.driveArcade(0.0,output)},
+    arrayOf(drivetrain)
+)
     {
   /**
    * Creates a new ExampleCommand.
@@ -27,12 +28,13 @@ class testPIDCommand(val TargetAngle: Double, val drivetrain = DrivetrainSubsyst
    * @param m_subsystem The subsystem used by this command.
    */
   init {
-    getController().enableContinuousInput(-180,180)
-    getController().setTolerance(Constants.Drive_kTurnToleranceDeg)
+    getController().enableContinuousInput(-180.0,180.0)
+    getController().setTolerance(Constants.TurnToAngleleranceDeg,Constants.TurnToAngleRateToleranceDegPerS)
   }
 
   // Returns true when the command should end.
   override fun isFinished(): Boolean {
+    if(!drivetrain.gyroUp()) return true
     return getController().atSetpoint();
   }
 }

--- a/src/main/kotlin/frc/robot/commands/testPIDCommand.kt
+++ b/src/main/kotlin/frc/robot/commands/testPIDCommand.kt
@@ -1,0 +1,38 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands
+
+import frc.robot.subsystems.*
+import frc.robot.Constants
+import edu.wpi.first.wpilibj2.command.CommandBase
+import edu.wpi.first.wpilibj2.command.PIDCommand
+import edu.wpi.first.wpilibj.controller.PIDController
+import edu.wpi.first.wpilibj.drive.DifferentialDrive
+
+class testPIDCommand(val TargetAngle: Double, val drivetrain = DrivetrainSubsystem(DifferentialDrive)) : PIDCommand(
+    PIDController(Constants.Drive_Kp,Constants.Drive_Ki,Constants.Drive_Kd),
+    drivetrain::getHeading,
+    targetAngle,
+    output -> drivetrain.arcadeDrive(0,0),
+    drive)
+    {
+  /**
+   * Creates a new ExampleCommand.
+   *
+   * @param m_subsystem The subsystem used by this command.
+   */
+  init {
+    getController().enableContinuousInput(-180,180)
+    getController().setTolerance(Constants.Drive_kTurnToleranceDeg)
+  }
+
+  // Returns true when the command should end.
+  override fun isFinished(): Boolean {
+    return getController().atSetpoint();
+  }
+}

--- a/src/main/kotlin/frc/robot/subsystems/DrivetrainSubsystem.kt
+++ b/src/main/kotlin/frc/robot/subsystems/DrivetrainSubsystem.kt
@@ -9,7 +9,7 @@ import edu.wpi.first.wpilibj.Encoder
  * Drivetrain subsystem
  * TODO: add gyro and encoder handling
  */
-class DrivetrainSubsystem(val drivetrain: DifferentialDrive, val gyroscope: AHRS, val encoderL: Encoder, val encoderR: Encoder) : SubsystemBase() {
+class DrivetrainSubsystem(val drivetrain: DifferentialDrive, val gyroscope: AHRS) : SubsystemBase() {
     /* default command (don't drive) */
     override fun periodic() {
         drivetrain.arcadeDrive(0.0, 0.0)
@@ -20,17 +20,17 @@ class DrivetrainSubsystem(val drivetrain: DifferentialDrive, val gyroscope: AHRS
         return gyroscope.getAngle()
     }
 
-    fun getLSpeed(): Double{
-        return encoderL.getRate()
-    }
+    //fun getLSpeed(): Double{
+    //    return encoderL.getRate()
+    //}
 
-    fun getRSpeed():Double{
-        return encoderR.getRate()
-    }
+    //fun getRSpeed():Double{
+    //    return encoderR.getRate()
+    //}
 
-    fun getOverallSpeed():Double{
-        return (encoderR.getRate()+encoderL.getRate())/2
-    }
+    //fun getOverallSpeed():Double{
+    //    return (encoderR.getRate()+encoderL.getRate())/2
+    //}
 
     /* return true if gyroscope is connected (gyro commands exit if it is not */
     fun gyroUp(): Boolean {

--- a/src/main/kotlin/frc/robot/subsystems/DrivetrainSubsystem.kt
+++ b/src/main/kotlin/frc/robot/subsystems/DrivetrainSubsystem.kt
@@ -3,12 +3,13 @@ package frc.robot.subsystems
 import edu.wpi.first.wpilibj2.command.SubsystemBase
 import edu.wpi.first.wpilibj.drive.DifferentialDrive
 import com.kauailabs.navx.frc.AHRS
+import edu.wpi.first.wpilibj.Encoder
 
 /**
  * Drivetrain subsystem
  * TODO: add gyro and encoder handling
  */
-class DrivetrainSubsystem(val drivetrain: DifferentialDrive, val gyroscope: AHRS) : SubsystemBase() {
+class DrivetrainSubsystem(val drivetrain: DifferentialDrive, val gyroscope: AHRS, val encoderL: Encoder, val encoderR: Encoder) : SubsystemBase() {
     /* default command (don't drive) */
     override fun periodic() {
         drivetrain.arcadeDrive(0.0, 0.0)
@@ -17,6 +18,18 @@ class DrivetrainSubsystem(val drivetrain: DifferentialDrive, val gyroscope: AHRS
     /* get angle returned by drivetrain */
     fun getAngle(): Double {
         return gyroscope.getAngle()
+    }
+
+    fun getLSpeed(): Double{
+        return encoderL.getRate()
+    }
+
+    fun getRSpeed():Double{
+        return encoderR.getRate()
+    }
+
+    fun getOverallSpeed():Double{
+        return (encoderR.getRate()+encoderL.getRate())/2
     }
 
     /* return true if gyroscope is connected (gyro commands exit if it is not */

--- a/src/main/kotlin/frc/robot/subsystems/testPidSubsystem.kt
+++ b/src/main/kotlin/frc/robot/subsystems/testPidSubsystem.kt
@@ -14,24 +14,23 @@ import edu.wpi.first.wpilibj.controller.PIDController
 import edu.wpi.first.wpilibj.controller.SimpleMotorFeedforward
 import edu.wpi.first.wpilibj.Encoder
 import frc.robot.Constants
+import com.kauailabs.navx.frc.AHRS
 
-class testPidSubsystem(val drivetrain: DifferentialDrive, val encoder: Encoder, val smff: SimpleMotorFeedforward) : PIDSubsystem(PIDController(Constants.Kp, Constants.Ki, Constants.Kd)) {
+class testPidSubsystem(val drivetrain: DifferentialDrive, val angle: Double, val smff: SimpleMotorFeedforward, val gyro: AHRS) : PIDSubsystem(PIDController(Constants.subsysP, Constants.subsysI, Constants.subsysD)) {
   /**
    * Creates a new ExampleSubsystem.
    */
-
     init{
-        encoder.setDistancePerPulse(Constants.dpp)
-        setSetpoint(Constants.kTargetRPS)
-        controller.setTolerance(Constants.kToleranceRPS)
+        setSetpoint(angle)
+        getController().enableContinuousInput(-180.0,180.0)
+        getController().setTolerance(Constants.TurnToAngleleranceDeg,Constants.TurnToAngleRateToleranceDegPerS)
     }
-
   /**
    * Will be called periodically whenever the CommandScheduler runs.
    */
 
   override fun getMeasurement(): Double {
-      return encoder.getRate();
+      return gyro.getAngle();
   }
   
   override fun useOutput(output:Double, setpoint:Double) {
@@ -39,11 +38,19 @@ class testPidSubsystem(val drivetrain: DifferentialDrive, val encoder: Encoder, 
   }
 
   fun atSetpoint(): Boolean{
-      return controller.atSetpoint() // controller is what?   
+      return getController().atSetpoint() // controller is what?   
   }
 
+  fun gyroUp(): Boolean{
+    return gyro.isConnected()
+  }
   fun stopDrivetrain() {
       drivetrain.arcadeDrive(0.0,0.0)
   }
+
+  fun driveArcade(forwardSpeed: Double, turnSpeed: Double, squareInputs: Boolean = false) {
+    drivetrain.arcadeDrive(forwardSpeed, turnSpeed, squareInputs)
+  }
+
 
 }

--- a/src/main/kotlin/frc/robot/subsystems/testPidSubsystem.kt
+++ b/src/main/kotlin/frc/robot/subsystems/testPidSubsystem.kt
@@ -1,0 +1,49 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.subsystems
+
+import edu.wpi.first.wpilibj2.command.SubsystemBase
+import edu.wpi.first.wpilibj.drive.DifferentialDrive
+import edu.wpi.first.wpilibj2.command.PIDSubsystem
+import edu.wpi.first.wpilibj.controller.PIDController
+import edu.wpi.first.wpilibj.controller.SimpleMotorFeedforward
+import edu.wpi.first.wpilibj.Encoder
+import frc.robot.Constants
+
+class testPidSubsystem(val drivetrain: DifferentialDrive, val encoder: Encoder, val smff: SimpleMotorFeedforward) : PIDSubsystem(PIDController(Constants.Kp, Constants.Ki, Constants.Kd)) {
+  /**
+   * Creates a new ExampleSubsystem.
+   */
+
+    init{
+        encoder.setDistancePerPulse(Constants.dpp)
+        setSetpoint(Constants.kTargetRPS)
+        controller.setTolerance(Constants.kToleranceRPS)
+    }
+
+  /**
+   * Will be called periodically whenever the CommandScheduler runs.
+   */
+
+  override fun getMeasurement(): Double {
+      return encoder.getRate();
+  }
+  
+  override fun useOutput(output:Double, setpoint:Double) {
+    drivetrain.arcadeDrive(1.0, output+smff.calculate(setpoint)) // this doesn't do what it should
+  }
+
+  fun atSetpoint(): Boolean{
+      return controller.atSetpoint() // controller is what?   
+  }
+
+  fun stopDrivetrain() {
+      drivetrain.arcadeDrive(0.0,0.0)
+  }
+
+}


### PR DESCRIPTION
Added ability to kill motors from Shuffleboard. Ignore changes to the `drivesubsystem.kt`, those require encoders that aren't on the robot right now.